### PR TITLE
CMakeLists: bump minimum cmake version to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Prefer GLVND libraries by default.
 if(POLICY CMP0072)


### PR DESCRIPTION
quiets a warning with newer CMake versions:
    
Compatibility with CMake < 2.8.12 will be removed from a future version
of CMake.
